### PR TITLE
Handle incomplete HTTP reads gracefully in comic scraper

### DIFF
--- a/gocomics-scrape.py
+++ b/gocomics-scrape.py
@@ -1,6 +1,7 @@
 #!/usr/local/bin/python
 
 import datetime
+import http.client
 import logging
 import html.parser
 import re
@@ -55,7 +56,11 @@ def get_homepage_data(strip_id):
   homepage_url = 'https://www.gocomics.com/%s' % strip_id
   homepage_file = open_url(homepage_url)
   parser = HomepageParser()
-  parser.feed(homepage_file.read().decode())
+  try:
+    parser.feed(homepage_file.read().decode())
+  except http.client.IncompleteRead as e:
+    logging.warning("Incomplete read for homepage %s: %s", homepage_url, e)
+    parser.feed(e.partial.decode())
   parser.close()
   homepage_file.close()
 
@@ -97,7 +102,11 @@ def get_strip_image_url(strip_url):
     else:
         logging.warning("Could not extract strip URL", exc_info=True)
         return None
-  parser.feed(strip_file.read().decode())
+  try:
+    parser.feed(strip_file.read().decode())
+  except http.client.IncompleteRead as e:
+    logging.warning("Incomplete read for strip %s: %s", strip_url, e)
+    parser.feed(e.partial.decode())
   parser.close()
   strip_file.close()
 


### PR DESCRIPTION
## Summary
Added error handling for incomplete HTTP reads when fetching comic homepages and strip images from GoComics. The scraper now catches `http.client.IncompleteRead` exceptions and processes the partial data that was successfully read instead of failing completely.

## Key Changes
- Added `import http.client` to support exception handling
- Wrapped `parser.feed()` calls in try-except blocks for both homepage and strip file parsing
- When an `IncompleteRead` exception occurs, the partial data is logged as a warning and fed to the parser for processing
- This allows the scraper to continue operating with incomplete responses rather than crashing

## Implementation Details
- Two locations were updated with identical error handling logic:
  1. Homepage parsing (around line 59)
  2. Strip file parsing (around line 105)
- The exception handler logs the incomplete read event with the relevant URL for debugging purposes
- Partial data from the exception object (`e.partial`) is decoded and processed, allowing the scraper to extract whatever information is available

https://claude.ai/code/session_01WrohUgAbJYxUipxJj6hdtg